### PR TITLE
Feature add election

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The election manager allows the user to manage election, candidates and voters.
+The election manager allows the user to manage elections, candidates and voters.
 
 https://electionmanagement-55ha.onrender.com
 

--- a/backend/src/main/java/org/example/backend/controller/ElectionController.java
+++ b/backend/src/main/java/org/example/backend/controller/ElectionController.java
@@ -37,7 +37,7 @@ public class ElectionController {
                         init.candidateIDs(),
                         new Vector<>(),
                         Election.ElectionState.OPEN,
-                        init.electionType(),
+                        init.electionMethod(),
                         init.candidateType(),
                         init.seats())),
                 HttpStatus.CREATED);

--- a/backend/src/main/java/org/example/backend/controller/ElectionController.java
+++ b/backend/src/main/java/org/example/backend/controller/ElectionController.java
@@ -2,10 +2,14 @@ package org.example.backend.controller;
 
 import org.example.backend.model.db.Candidate;
 import org.example.backend.model.db.Election;
+import org.example.backend.model.db.ElectionDTO;
 import org.example.backend.service.ElectionService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Vector;
 
 @RestController
 @RequestMapping("/api/election")
@@ -19,6 +23,38 @@ public class ElectionController {
     @GetMapping
     public List<Election> getAllElections() { return electionService.getAllElections(); }
 
+    @PostMapping
+    public ResponseEntity<Election> createElection(@RequestBody ElectionDTO init) {
+        List<Election> allElections = electionService.getAllElections();
+        if(!allElections.stream().filter(electionDB -> electionDB.id().equals(init.id())).toList().isEmpty()) {
+            throw new Election.DuplicateIdException();
+        } else {
+            return new ResponseEntity<>(
+                electionService.createElection(new Election(
+                        init.id(),
+                        init.name(),
+                        init.description(),
+                        init.candidateIDs(),
+                        new Vector<>(),
+                        Election.ElectionState.OPEN,
+                        init.electionType(),
+                        init.candidateType(),
+                        init.seats())),
+                HttpStatus.CREATED);
+        }
+    }
+
+    @PutMapping
+    public ResponseEntity<Election> updateElection(@RequestBody Election election) {
+        List<Election> allElections = electionService.getAllElections();
+        if(allElections.stream().filter(electionDB -> electionDB.id().equals(election.id())).toList().isEmpty()) {
+            throw new Election.IdNotFoundException();
+        } else {
+            return new ResponseEntity<>(
+                electionService.updateElection(election),
+                HttpStatus.ACCEPTED);
+        }
+    }
 
     @GetMapping("/candidates")
     public List<Candidate> getAllCandidates() { return electionService.getAllCandidates(); }

--- a/backend/src/main/java/org/example/backend/model/db/Election.java
+++ b/backend/src/main/java/org/example/backend/model/db/Election.java
@@ -11,16 +11,20 @@ public record Election(
         Vector<String> candidateIDs,
         Vector<Vote> votes,
         ElectionState electionState,
-        ElectionType electionType,
+        ElectionType electionMethod,
         String candidateType,
         int seats) {
 
     public enum ElectionState {OPEN, VOTING, CLOSED}
     public enum ElectionType {STV, VICE}
 
-    @ResponseStatus(value= HttpStatus.FORBIDDEN, reason="Duplicate ID")
-    public static class DuplicateIdException extends RuntimeException {}
+    @ResponseStatus(value= HttpStatus.FORBIDDEN, reason=DuplicateIdException.reason)
+    public static class DuplicateIdException extends RuntimeException {
+        public static final String reason = "Duplicate ID";
+    }
 
-    @ResponseStatus(value= HttpStatus.NOT_FOUND, reason="ID not found")
-    public static class IdNotFoundException extends RuntimeException {}
+    @ResponseStatus(value= HttpStatus.NOT_FOUND, reason=IdNotFoundException.reason)
+    public static class IdNotFoundException extends RuntimeException {
+        public static final String reason = "ID not found";
+    }
 }

--- a/backend/src/main/java/org/example/backend/model/db/Election.java
+++ b/backend/src/main/java/org/example/backend/model/db/Election.java
@@ -1,6 +1,9 @@
 package org.example.backend.model.db;
 
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
 import java.util.Vector;
 
 public record Election(
@@ -15,4 +18,9 @@ public record Election(
     public enum ElectionState {OPEN, VOTING, CLOSED}
     public enum ElectionType {STV, VICE}
 
+    @ResponseStatus(value= HttpStatus.FORBIDDEN, reason="Duplicate ID")
+    public static class DuplicateIdException extends RuntimeException {}
+
+    @ResponseStatus(value= HttpStatus.NOT_FOUND, reason="ID not found")
+    public static class IdNotFoundException extends RuntimeException {}
 }

--- a/backend/src/main/java/org/example/backend/model/db/ElectionDTO.java
+++ b/backend/src/main/java/org/example/backend/model/db/ElectionDTO.java
@@ -5,7 +5,7 @@ import java.util.Vector;
 public record ElectionDTO(
         String id, String name, String description,
           Vector<String> candidateIDs,
-          Election.ElectionType electionType,
+          Election.ElectionType electionMethod,
           String candidateType,
           int seats) {
 }

--- a/backend/src/main/java/org/example/backend/model/db/ElectionDTO.java
+++ b/backend/src/main/java/org/example/backend/model/db/ElectionDTO.java
@@ -1,0 +1,11 @@
+package org.example.backend.model.db;
+
+import java.util.Vector;
+
+public record ElectionDTO(
+        String id, String name, String description,
+          Vector<String> candidateIDs,
+          Election.ElectionType electionType,
+          String candidateType,
+          int seats) {
+}

--- a/backend/src/main/java/org/example/backend/service/ElectionService.java
+++ b/backend/src/main/java/org/example/backend/service/ElectionService.java
@@ -19,6 +19,8 @@ public class ElectionService {
     }
 
     public List<Election> getAllElections() { return electionRepo.findAll(); }
+    public Election createElection(Election election) { return electionRepo.save(election); }
+    public Election updateElection(Election election) { return electionRepo.save(election); }
 
     public List<Candidate> getAllCandidates() { return candidateRepo.findAll(); }
 

--- a/backend/src/test/java/org/example/backend/controller/ElectionControllerTest.java
+++ b/backend/src/test/java/org/example/backend/controller/ElectionControllerTest.java
@@ -132,7 +132,7 @@ public class ElectionControllerTest {
         mockMvc.perform(MockMvcRequestBuilders.post("/api/election")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                {
+                                {
                                     "id": "1",
                                     "name": "MyElection",
                                     "description": "some details",
@@ -140,11 +140,97 @@ public class ElectionControllerTest {
                                     "candidateType": "Person",
                                     "electionMethod": "STV",
                                     "seats": 3
-                }
-                """))
+                                }
+                                """))
                 //THEN
                 .andExpect(MockMvcResultMatchers.status().isForbidden())
                 .andExpect(MockMvcResultMatchers.status().reason(Election.DuplicateIdException.reason));
+    }
+
+
+    @Test
+    void updateElectionSuccess() throws Exception {
+        //GIVEN
+        Election existingElection = new Election(
+                "1",
+                "MyElection",
+                "some details",
+                new Vector<>(),
+                new Vector<>(),
+                Election.ElectionState.OPEN,
+                Election.ElectionType.STV,
+                "Person",
+                3);
+        electionRepo.save(existingElection);
+        //WHEN
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/election")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "id": "1",
+                                    "name": "MyElection",
+                                    "description": "some other details",
+                                    "candidateIDs": [],
+                                    "electionState": "OPEN",
+                                    "votes": [],
+                                    "candidateType": "Person",
+                                    "electionMethod": "STV",
+                                    "seats": 4
+                                }
+                                """))
+                //THEN
+                .andExpect(MockMvcResultMatchers.status().isAccepted())
+                .andExpect(MockMvcResultMatchers.content().json(
+                        """ 
+                                {
+                                    "id": "1",
+                                    "name": "MyElection",
+                                    "description": "some other details",
+                                    "candidateIDs": [],
+                                    "electionState": "OPEN",
+                                    "votes": [],
+                                    "candidateType": "Person",
+                                    "electionMethod": "STV",
+                                    "seats": 4
+                                }
+                                """));
+    }
+
+    @Test
+    void updateElectionNotFound() throws Exception {
+        //GIVEN
+        Election existingElection = new Election(
+                "1",
+                "MyElection",
+                "some details",
+                new Vector<>(),
+                new Vector<>(),
+                Election.ElectionState.OPEN,
+                Election.ElectionType.STV,
+                "Person",
+                3);
+        electionRepo.save(existingElection);
+        //WHEN
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/election")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "id": "404",
+                                    "name": "MyElection",
+                                    "description": "some other details",
+                                    "candidateIDs": [],
+                                    "electionState": "OPEN",
+                                    "votes": [],
+                                    "candidateType": "Person",
+                                    "electionMethod": "STV",
+                                    "seats": 4
+                                }
+                                """))
+                //THEN
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andExpect(MockMvcResultMatchers.status().reason(Election.IdNotFoundException.reason));
     }
 
     @Test

--- a/backend/src/test/java/org/example/backend/service/ElectionServiceTest.java
+++ b/backend/src/test/java/org/example/backend/service/ElectionServiceTest.java
@@ -17,8 +17,7 @@ class ElectionServiceTest {
 
     @Test
     void getAllElections() {
-        // given
-
+        // GIVEN
         ElectionRepo electionRepo = Mockito.mock(ElectionRepo.class);
         CandidateRepo candidateRepo = Mockito.mock(CandidateRepo.class);
         ElectionService electionService = new ElectionService(electionRepo, candidateRepo);
@@ -33,11 +32,11 @@ class ElectionServiceTest {
                 "Person",
                 3);
 
-        // when
+        // WHEN
         when(electionRepo.findAll()).thenReturn(java.util.List.of(election));
         java.util.List<Election> result = electionService.getAllElections();
 
-        // then
+        // THEN
         assertThat(result)
                 .hasSize(1)
                 .containsExactly(election);
@@ -45,6 +44,32 @@ class ElectionServiceTest {
         verifyNoMoreInteractions(electionRepo);
     }
 
+    @Test
+    void createElection() {
+        //GIVEN
+        ElectionRepo electionRepo = Mockito.mock(ElectionRepo.class);
+        CandidateRepo candidateRepo = Mockito.mock(CandidateRepo.class);
+        ElectionService electionService = new ElectionService(electionRepo, candidateRepo);
+        Election election = new Election(
+                "1",
+                "MyElection",
+                "some details",
+                new Vector<>(),
+                new Vector<>(),
+                Election.ElectionState.OPEN,
+                Election.ElectionType.STV,
+                "Person",
+                3);
+        //WHEN
+        when(electionRepo.save(election)).thenReturn(election);
+        Election result = electionService.createElection(election);
+
+        //THEN
+        assertThat(result)
+                .isEqualTo(election);
+        verify(electionRepo, times(1)).save(election);
+        verifyNoMoreInteractions(electionRepo);
+    }
 
     @Test
     void getAllCandidates() {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -51,3 +51,11 @@ div.navigation-item > p {
 div.navigation-item > img {
   padding: 4px;
 }
+
+p.error-message {
+  color: #b00;
+  background-color: #faa;
+  border-radius: 10px;
+  border: 3px #b00 solid;
+  padding: 10px;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,7 +68,7 @@ function App() {
     // functions to backend for editing
     function createElection():void {
         axios.post("/api/election", editElectionProps.election)
-            .then(() => {getAllElectionsAndCandidates(); nav("/")})
+            .then(() => {getAllElectionsAndCandidates(); editElectionProps.onSuccess()})
             .catch(error => {
                 console.log(error);
                 console.log(error.status);
@@ -81,7 +81,7 @@ function App() {
 
     function updateElection(election:Election) {
         axios.put("/api/election", election)
-            .then(() => {getAllElectionsAndCandidates(); nav("/")})
+            .then(() => {getAllElectionsAndCandidates(); editElectionProps.onSuccess()})
             .catch(error => {
                 console.log(error);
                 if(error.response && error.response.status == 404) {

--- a/frontend/src/ElectionData.ts
+++ b/frontend/src/ElectionData.ts
@@ -6,7 +6,7 @@ export type Election = {
     seats:number;
     candidateIDs:string[];
     candidateType:string;
-    electionType:string;
+    electionMethod:string;
     votes:Vote[];
 }
 

--- a/frontend/src/ElectionForm.tsx
+++ b/frontend/src/ElectionForm.tsx
@@ -4,6 +4,7 @@ import type {FormEvent} from "react";
 export type EditElectionFormProps = {
     editMode:boolean;
     election:Election;
+    error:string|null;
     candidates:Candidate[];
     onEdit:(election:Election)=>void;
     onSubmit:()=>void
@@ -95,8 +96,10 @@ export default function ElectionForm(props:Readonly<EditElectionFormProps>) {
                 <tr>
                     <td>id</td>
                     <td>
-                        <input value={props.election.id}
+                        {props.editMode?props.election.id:
+                            <input value={props.election.id}
                                onChange={(e) => changeID(e.target.value)}/>
+                        }
                     </td>
                 </tr>
                 <tr>
@@ -163,6 +166,7 @@ export default function ElectionForm(props:Readonly<EditElectionFormProps>) {
                 </tr>
                 </tbody>
             </table>
+            {props.error?<p className={"error-message"}>{props.error}</p>:""}
             <form onSubmit={(e) => submit(e)}><button>Submit</button></form>
         </div>
     )

--- a/frontend/src/ElectionForm.tsx
+++ b/frontend/src/ElectionForm.tsx
@@ -1,0 +1,169 @@
+import type {Candidate, Election} from "./ElectionData.ts";
+import type {FormEvent} from "react";
+
+export type EditElectionFormProps = {
+    editMode:boolean;
+    election:Election;
+    candidates:Candidate[];
+    onEdit:(election:Election)=>void;
+    onSubmit:()=>void
+}
+
+export default function ElectionForm(props:Readonly<EditElectionFormProps>) {
+
+    function submit(e:FormEvent<HTMLFormElement> ):void {
+        e.preventDefault();
+        props.onSubmit();
+    }
+
+    function changeID(value:string) {
+        const election = {
+            ...props.election,
+            id:value,
+        }
+        props.onEdit(election)
+    }
+
+    function changeName(value:string) {
+        const election = {
+            ...props.election,
+            name:value,
+        }
+        props.onEdit(election)
+    }
+
+    function changeDescription(value:string) {
+        const election = {
+            ...props.election,
+            description:value,
+        }
+        props.onEdit(election)
+    }
+
+    function changeType(value:string) {
+        const election = {
+            ...props.election,
+            electionType:value,
+        }
+        props.onEdit(election)
+    }
+
+    function changeSeats(value:number) {
+        const election = {
+            ...props.election,
+            seats:value,
+        }
+        props.onEdit(election)
+    }
+
+    function changeMethod(value:string) {
+        const election = {
+            ...props.election,
+            electionMethod:value,
+        }
+        props.onEdit(election)
+    }
+
+    function getAvailableCandidates(election:Election, candidates:Candidate[]) {
+        return candidates.filter((cc) => election.candidateIDs.indexOf(cc.id) == -1);
+    }
+
+    function getRunningCandidates(election:Election, candidates:Candidate[]) {
+        let result:Candidate[] = [];
+        election.candidateIDs.forEach((ecID) => {
+            const c:Candidate[] = candidates.filter((cc) => cc.id == ecID);
+            if(c.length == 1) {
+                console.log("result: "+result);
+                console.log("c: "+c);
+                result = result.concat(c);
+            }
+        })
+        return result;
+    }
+
+    const candidatesEditable:boolean = props.election.electionState=="OPEN";
+    const availableCandidates:Candidate[] = candidatesEditable?
+        getAvailableCandidates(props.election, props.candidates):[];
+    const runningCandidates:Candidate[] =
+        getRunningCandidates(props.election, props.candidates);
+
+
+    return(
+        <div style={{display:"flex", flexDirection:"column"}}>
+            <table>
+                <tbody>
+                <tr>
+                    <td>id</td>
+                    <td>
+                        <input value={props.election.id}
+                               onChange={(e) => changeID(e.target.value)}/>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Name</td>
+                    <td>
+                        <input value={props.election.name}
+                               onChange={(e) => changeName(e.target.value)}/>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Description</td>
+                    <td>
+                        <textarea value={props.election.description}
+                                  onChange={(e) => changeDescription(e.target.value)}/>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Seats</td>
+                    <td>
+                        <input
+                            type={"number"}
+                            value={props.election.seats}
+                            onChange={(e) => changeSeats(e.target.valueAsNumber)}/>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Election Method</td>
+                    <td>
+                        <select name="candidate-types" id="candidate-types"
+                                onChange={(e) => {changeMethod(e.target.value)}}
+                                defaultValue={props.election.electionMethod}>
+                            <option value={"STV"}>STV</option>
+                            <option value={"Test"}>Test</option>
+                        </select>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Candidate Type</td>
+                    <td>
+                        <input value={props.election.candidateType}
+                               onChange={(e) => changeType(e.target.value)}/>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+            <table>
+                <thead>
+                <tr><td>Running Candidates</td><td>Available Candidates</td></tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <td><div style={{
+                        display:"flex",
+                        flexDirection: "column",
+                        alignItems: "flex-start"}}>{runningCandidates.map((candidate) => {return (candidate.name)})}
+                    </div></td>
+
+                    <td><div style={{
+                        display:"flex",
+                        flexDirection: "row",
+                        flexWrap: "wrap",
+                        alignItems: "flex-start"}}>{availableCandidates.map((candidate) => {return (candidate.name)})}
+                    </div></td>
+                </tr>
+                </tbody>
+            </table>
+            <form onSubmit={(e) => submit(e)}><button>Submit</button></form>
+        </div>
+    )
+}

--- a/frontend/src/ElectionForm.tsx
+++ b/frontend/src/ElectionForm.tsx
@@ -92,6 +92,11 @@ export default function ElectionForm(props:Readonly<EditElectionFormProps>) {
     return(
         <div style={{display:"flex", flexDirection:"column"}}>
             <table>
+                <thead>
+                    <tr>
+                        <th>Key</th><th>Value</th>
+                    </tr>
+                </thead>
                 <tbody>
                 <tr>
                     <td>id</td>
@@ -147,7 +152,7 @@ export default function ElectionForm(props:Readonly<EditElectionFormProps>) {
             </table>
             <table>
                 <thead>
-                <tr><td>Running Candidates</td><td>Available Candidates</td></tr>
+                <tr><th>Running Candidates</th><th>Available Candidates</th></tr>
                 </thead>
                 <tbody>
                 <tr>

--- a/frontend/src/ElectionTable.tsx
+++ b/frontend/src/ElectionTable.tsx
@@ -2,11 +2,14 @@ import type {Election} from "./ElectionData.ts";
 
 export type ElectionTableProps = {
     value:Election[];
+    onCreateElection:()=>void;
+    onEditElection:(election:Election)=>void;
 }
 
 export default function ElectionTable(props:Readonly<ElectionTableProps>) {
     return(
         <>
+            <button onClick={() => props.onCreateElection()}>Create</button>
             <table border={1}>
                 <thead>
                 <tr>
@@ -22,13 +25,15 @@ export default function ElectionTable(props:Readonly<ElectionTableProps>) {
                 {props.value.map((election) => {
 
                     return(
-                        <tr>
+                        <tr key={election.id}>
                             <td>{election.id}</td>
                             <td>{election.name}</td>
                             <td>{election.electionState}</td>
                             <td>{election.description}</td>
                             <td>TBD</td>
-                            <td>TBD</td>
+                            <td>
+                                <button onClick={() => props.onEditElection(election)}>Edit</button>
+                            </td>
                         </tr>
                     )})}
                 </tbody>


### PR DESCRIPTION
This branch adds a form for editing elections. It can be used for adding new elections or for editing existing ones.
The election id can be freely chosen, but is checked for duplicates, and cannot be changed thereafter. 
Only one election method is available yet. Candidate Type has no effect yet. Candidates cannot be edited yet. Election status cannot be changed, on create it is always 'open'. 

On success the page returns to the election table. On fail, it remains on the edit form, displaying an error near the submit button.