### PR TITLE
Feature add status archived

### DIFF
--- a/backend/src/main/java/org/example/backend/model/db/Candidate.java
+++ b/backend/src/main/java/org/example/backend/model/db/Candidate.java
@@ -9,10 +9,11 @@ public record Candidate(
         String party,
         String color,
         String description,
-        String type) {
+        String type,
+        boolean archived) {
 
     public Candidate(CandidateDTO init, String id) {
-        this(id, init.name(), init.party(), init.color(), init.description(), init.type());
+        this(id, init.name(), init.party(), init.color(), init.description(), init.type(), false);
     }
 
     @ResponseStatus(value= HttpStatus.NOT_FOUND, reason= Election.IdNotFoundException.reason)

--- a/backend/src/main/java/org/example/backend/model/db/Election.java
+++ b/backend/src/main/java/org/example/backend/model/db/Election.java
@@ -15,7 +15,7 @@ public record Election(
         String candidateType,
         int seats) {
 
-    public enum ElectionState {OPEN, VOTING, CLOSED}
+    public enum ElectionState {OPEN, VOTING, CLOSED, ARCHIVED}
     public enum ElectionType {STV, VICE}
 
     @ResponseStatus(value= HttpStatus.FORBIDDEN, reason=DuplicateIdException.reason)

--- a/backend/src/test/java/org/example/backend/controller/ElectionControllerTest.java
+++ b/backend/src/test/java/org/example/backend/controller/ElectionControllerTest.java
@@ -30,6 +30,25 @@ public class ElectionControllerTest {
     @Autowired
     private CandidateRepo candidateRepo;
 
+    Candidate defaultCandidate = new Candidate(
+            "1",
+            "John Doe",
+            "Independent",
+            "#444",
+            "some details",
+            "Person",
+            false);
+
+    Election defaultElection = new Election(
+            "1",
+            "MyElection",
+            "some details",
+            new ArrayList<>(),
+            new ArrayList<>(),
+            Election.ElectionState.OPEN,
+            Election.ElectionType.STV,
+            "Person",
+            3);
     @Test
     void getAllProducts() throws Exception {
 
@@ -72,16 +91,8 @@ public class ElectionControllerTest {
     @Test
     void createElectionSuccess() throws Exception {
         //GIVEN
-        Election existingElection = new Election(
-                "1",
-                "MyElection",
-                "some details",
-                new ArrayList<>(),
-                new ArrayList<>(),
-                Election.ElectionState.OPEN,
-                Election.ElectionType.STV,
-                "Person",
-                3);
+        Election existingElection = defaultElection;
+        electionRepo.deleteAll();
         electionRepo.save(existingElection);
         //WHEN
 
@@ -119,19 +130,11 @@ public class ElectionControllerTest {
     @Test
     void createElectionDuplicate() throws Exception {
         //GIVEN
-        Election existingElection = new Election(
-                "1",
-                "MyElection",
-                "some details",
-                new ArrayList<>(),
-                new ArrayList<>(),
-                Election.ElectionState.OPEN,
-                Election.ElectionType.STV,
-                "Person",
-                3);
+        Election existingElection = defaultElection;
+        electionRepo.deleteAll();
         electionRepo.save(existingElection);
-        //WHEN
 
+        //WHEN
         mockMvc.perform(MockMvcRequestBuilders.post("/api/election")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
@@ -154,19 +157,11 @@ public class ElectionControllerTest {
     @Test
     void updateElectionSuccess() throws Exception {
         //GIVEN
-        Election existingElection = new Election(
-                "1",
-                "MyElection",
-                "some details",
-                new ArrayList<>(),
-                new ArrayList<>(),
-                Election.ElectionState.OPEN,
-                Election.ElectionType.STV,
-                "Person",
-                3);
+        Election existingElection = defaultElection;
+        electionRepo.deleteAll();
         electionRepo.save(existingElection);
-        //WHEN
 
+        //WHEN
         mockMvc.perform(MockMvcRequestBuilders.put("/api/election")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
@@ -203,19 +198,11 @@ public class ElectionControllerTest {
     @Test
     void updateElectionNotFound() throws Exception {
         //GIVEN
-        Election existingElection = new Election(
-                "1",
-                "MyElection",
-                "some details",
-                new ArrayList<>(),
-                new ArrayList<>(),
-                Election.ElectionState.OPEN,
-                Election.ElectionType.STV,
-                "Person",
-                3);
+        Election existingElection = defaultElection;
+        electionRepo.deleteAll();
         electionRepo.save(existingElection);
-        //WHEN
 
+        //WHE
         mockMvc.perform(MockMvcRequestBuilders.put("/api/election")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
@@ -240,13 +227,7 @@ public class ElectionControllerTest {
     void getAllCandidates() throws Exception {
 
         //GIVEN
-        Candidate candidate = new Candidate(
-                "-1",
-                "John Doe",
-                "Independent",
-                "#444",
-                "some details",
-                "Person");
+        Candidate candidate = defaultCandidate;
         candidateRepo.deleteAll();
         candidateRepo.save(candidate);
 
@@ -262,7 +243,8 @@ public class ElectionControllerTest {
                                     "description": "some details",
                                     "party": "Independent",
                                     "color": "#444",
-                                    "type": "Person"
+                                    "type": "Person",
+                                    "archived": false
                                   }
                                 ]
                                 """))
@@ -283,7 +265,8 @@ public class ElectionControllerTest {
                                     "description": "some details",
                                     "party": "Independent",
                                     "color": "#444",
-                                    "type": "Person"
+                                    "type": "Person",
+                                    "archived": false
                                 }
                                 """))
                 //THEN
@@ -295,7 +278,8 @@ public class ElectionControllerTest {
                                     "description": "some details",
                                     "party": "Independent",
                                     "color": "#444",
-                                    "type": "Person"
+                                    "type": "Person",
+                                    "archived": false
                                 }
                                 """))
                 .andExpect(MockMvcResultMatchers.jsonPath("id").isNotEmpty());
@@ -304,16 +288,11 @@ public class ElectionControllerTest {
     @Test
     void updateCandidateSuccess() throws Exception {
         //GIVEN
-        Candidate existingCandidate = new Candidate(
-                "1",
-                "John Doe",
-                "Independent",
-                "#444",
-                "some details",
-                "Person");
-        candidateRepo.save(existingCandidate);
-        //WHEN
+        Candidate candidate = defaultCandidate;
+        candidateRepo.deleteAll();
+        candidateRepo.save(candidate);
 
+        //WHEN
         mockMvc.perform(MockMvcRequestBuilders.put("/api/election/candidates")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
@@ -323,7 +302,8 @@ public class ElectionControllerTest {
                                     "description": "some details",
                                     "party": "Independent",
                                     "color": "#555",
-                                    "type": "Person"
+                                    "type": "Person",
+                                    "archived": false
                                 }
                                 """))
                 //THEN
@@ -336,7 +316,8 @@ public class ElectionControllerTest {
                                     "description": "some details",
                                     "party": "Independent",
                                     "color": "#555",
-                                    "type": "Person"
+                                    "type": "Person",
+                                    "archived": false
                                 }
                                 """));
     }
@@ -344,16 +325,11 @@ public class ElectionControllerTest {
     @Test
     void updateCandidateNotFound() throws Exception {
         //GIVEN
-        Candidate existingCandidate = new Candidate(
-                "1",
-                "John Doe",
-                "Independent",
-                "#444",
-                "some details",
-                "Person");
-        candidateRepo.save(existingCandidate);
-        //WHEN
+        Candidate candidate = defaultCandidate;
+        candidateRepo.deleteAll();
+        candidateRepo.save(candidate);
 
+        //WHEN
         mockMvc.perform(MockMvcRequestBuilders.put("/api/election/candidates")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
@@ -363,7 +339,8 @@ public class ElectionControllerTest {
                                     "description": "some details",
                                     "party": "Independent",
                                     "color": "#555",
-                                    "type": "Person"
+                                    "type": "Person",
+                                    "archived": false
                                 }
                                 """))
                 //THEN
@@ -385,9 +362,9 @@ public class ElectionControllerTest {
                 "any",
                 1);
         electionRepo.save(existingElection);
-        candidateRepo.save(new Candidate("A", "Alice", "", "", "", ""));
-        candidateRepo.save(new Candidate("B", "Bob", "", "", "", ""));
-        candidateRepo.save(new Candidate("C", "Charlie", "", "", "", ""));
+        candidateRepo.save(new Candidate("A", "Alice", "", "", "", "", false));
+        candidateRepo.save(new Candidate("B", "Bob", "", "", "", "", false));
+        candidateRepo.save(new Candidate("C", "Charlie", "", "", "", "", false));
 
         //WHEN
         mockMvc.perform(MockMvcRequestBuilders.get("/api/election/results/myID"))

--- a/backend/src/test/java/org/example/backend/model/count/MeekAlgorithmTest.java
+++ b/backend/src/test/java/org/example/backend/model/count/MeekAlgorithmTest.java
@@ -15,11 +15,11 @@ class MeekAlgorithmTest {
 
     private ArrayList<Candidate> getDefaultCandidates() {
         ArrayList<Candidate> candidates = new ArrayList<>();
-        candidates.add(new Candidate("A", "Alice", "", "", "", ""));
-        candidates.add(new Candidate("B", "Bob", "", "", "", ""));
-        candidates.add(new Candidate("C", "Charlie", "", "", "", ""));
-        candidates.add(new Candidate("D", "David", "", "", "", ""));
-        candidates.add(new Candidate("E", "Eve", "", "", "", ""));
+        candidates.add(new Candidate("A", "Alice", "", "", "", "", false));
+        candidates.add(new Candidate("B", "Bob", "", "", "", "", false));
+        candidates.add(new Candidate("C", "Charlie", "", "", "", "", false));
+        candidates.add(new Candidate("D", "David", "", "", "", "", false));
+        candidates.add(new Candidate("E", "Eve", "", "", "", "", false));
         return candidates;
     }
 

--- a/backend/src/test/java/org/example/backend/service/ElectionServiceTest.java
+++ b/backend/src/test/java/org/example/backend/service/ElectionServiceTest.java
@@ -80,7 +80,8 @@ class ElectionServiceTest {
                 "Independent",
                 "#444",
                 "some details",
-                "Person");
+                "Person",
+                false);
 
         //WHEN
         when(candidateRepo.findAll()).thenReturn(java.util.List.of(candidate));
@@ -107,7 +108,8 @@ class ElectionServiceTest {
                 "Independent",
                 "#444",
                 "some details",
-                "Person");
+                "Person",
+                false);
 
         //WHEN
         when(candidateRepo.save(candidate)).thenReturn(candidate);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,7 +34,7 @@ function App() {
     const defaultCandidate:Candidate = {
         id:"(automatically assigned)", name:"John Doe",
         description:"an average candidate",
-        party:"Independent", color:"888", type:"Person"
+        party:"Independent", color:"888", type:"Person", archived:false
     };
 
     // temporary variables for forms
@@ -201,6 +201,7 @@ function App() {
                 elections={elections}
                 candidates={candidates}
                 onGetResult={getElectionResults}
+                isArchive={false}
                 onCreateElection={() => {
                     setEditElectionProps({
                         election:defaultElection,
@@ -272,7 +273,14 @@ function App() {
                 onSubmit={() => updateCandidate(editCandidateProps.candidate)}
             />}/>
             <Route path={"/vote/"} element={"This is the vote page"}/>
-            <Route path={"/archive/"} element={"This is the archive page"}/>
+            <Route path={"/archive/"} element={<ElectionTable
+                    elections={elections}
+                    candidates={candidates}
+                    onGetResult={getElectionResults}
+                    isArchive={true}
+                    onCreateElection={() => {}}
+                    onEditElection={() => {}}
+            />}/>
             <Route path={"/result/"} element={"This is the result page"}/>
         </Routes>
     </div>

--- a/frontend/src/CandidateTable.tsx
+++ b/frontend/src/CandidateTable.tsx
@@ -59,7 +59,7 @@ export default function CandidateTable(props:Readonly<CandidateTableProps>) {
                     .filter(candidate => {return typeFilter===null || typeFilter===candidate.type})
                     .map((candidate) => {
                     return (
-                        <tr>
+                        <tr key={candidate.id}>
                             <td>{candidate.name}</td>
                             <td>{candidate.party}</td>
                             <td>{candidate.description}</td>

--- a/frontend/src/ElectionData.ts
+++ b/frontend/src/ElectionData.ts
@@ -21,6 +21,7 @@ export type Candidate = {
     party:string;
     color:string;
     type:string;
+    archived:boolean;
 }
 
 export type ElectionResultItem = {

--- a/frontend/src/ElectionTable.tsx
+++ b/frontend/src/ElectionTable.tsx
@@ -7,25 +7,28 @@ export type ElectionTableProps = {
     onCreateElection:()=>void;
     onEditElection:(election:Election)=>void;
     onGetResult:(election:Election)=>void;
+    isArchive:boolean;
 }
 
 export default function ElectionTable(props:Readonly<ElectionTableProps>) {
     return(
         <>
-            <button onClick={() => props.onCreateElection()}>Create</button>
+        {props.isArchive?"":<button onClick={() => props.onCreateElection()}>Create</button>}
             <table border={1}>
                 <thead>
                 <tr>
                     <th>ID</th>
                     <th>Name</th>
-                    <th>Status</th>
                     <th>Info</th>
                     <th>Candidates</th>
+                    <th>Seats</th>
                     <th>Actions</th>
                 </tr>
                 </thead>
                 <tbody>
-                {props.elections.map((election) => {
+                {props.elections
+                    .filter(election => (election.electionState === "ARCHIVED") === props.isArchive)
+                    .map((election) => {
                     let candidates:Candidate[] = [];
                     election.candidateIDs.forEach((id) => {
                         candidates = candidates.concat(props.candidates.filter(
@@ -36,16 +39,35 @@ export default function ElectionTable(props:Readonly<ElectionTableProps>) {
                         <tr key={election.id}>
                             <td>{election.id}</td>
                             <td>{election.name}</td>
-                            <td>{election.electionState}</td>
                             <td>{election.description}</td>
                             <td><div style={{display:"flex", flexDirection:"row", flexWrap:"wrap"}}>
                                 {candidates.map(candidate => {return(
                                     <CandidateBox candidate={candidate}/>
                                 )})}
                             </div></td>
+                            <td>{election.seats}</td>
                             <td>
-                                <button onClick={() => props.onEditElection(election)}>Edit</button>
-                                <button onClick={() => props.onGetResult(election)}>Result</button>
+                                {election.electionState === "OPEN"?
+                                    <>
+                                        <button onClick={() => props.onEditElection(election)}>Edit</button>
+                                        <button><s>Open Voting</s></button>
+                                    </>
+                                :election.electionState === "VOTING"?
+                                    <>
+                                        <button><s>Close Voting</s></button>
+                                        <button><s>Vote</s></button>
+                                    </>
+                                :election.electionState === "CLOSED"?
+                                    <>
+                                        <button onClick={() => props.onGetResult(election)}>Result</button>
+                                        <button><s>Archive</s></button>
+                                    </>
+                                :
+                                    <>
+                                        <button onClick={() => props.onGetResult(election)}>Result</button>
+                                    </>
+                                }
+                                <button><s>Delete</s></button>
                             </td>
                         </tr>
                     )})}

--- a/frontend/src/ElectionTable.tsx
+++ b/frontend/src/ElectionTable.tsx
@@ -11,6 +11,42 @@ export type ElectionTableProps = {
 }
 
 export default function ElectionTable(props:Readonly<ElectionTableProps>) {
+
+    function getDeleteButton(election:Election) {
+        return (<button><s>Delete</s></button>)
+    }
+
+    function getResultButton(election:Election) {
+        return (<button onClick={() => props.onGetResult(election)}>Result</button>)
+    }
+
+    function getButtons(election:Election) {
+        if(election.electionState==="OPEN") {
+            return(<>
+                <button onClick={() => props.onEditElection(election)}>Edit</button>
+                <button><s>Open Voting</s></button>
+                {getDeleteButton(election)}
+            </>)
+        } else if(election.electionState==="VOTING") {
+            return(<>
+                <button><s>Close Voting</s></button>
+                <button><s>Vote</s></button>
+                {getDeleteButton(election)}
+            </>)
+        } else if(election.electionState==="CLOSED") {
+            return(<>
+                {getResultButton(election)}
+                <button><s>Archive</s></button>
+                {getDeleteButton(election)}
+            </>)
+        } else { // ARCHIVED
+            return (<>
+                {getResultButton(election)}
+                {getDeleteButton(election)}
+            </>)
+        }
+    }
+
     return(
         <>
         {props.isArchive?"":<button onClick={() => props.onCreateElection()}>Create</button>}
@@ -46,29 +82,7 @@ export default function ElectionTable(props:Readonly<ElectionTableProps>) {
                                 )})}
                             </div></td>
                             <td>{election.seats}</td>
-                            <td>
-                                {election.electionState === "OPEN"?
-                                    <>
-                                        <button onClick={() => props.onEditElection(election)}>Edit</button>
-                                        <button><s>Open Voting</s></button>
-                                    </>
-                                :election.electionState === "VOTING"?
-                                    <>
-                                        <button><s>Close Voting</s></button>
-                                        <button><s>Vote</s></button>
-                                    </>
-                                :election.electionState === "CLOSED"?
-                                    <>
-                                        <button onClick={() => props.onGetResult(election)}>Result</button>
-                                        <button><s>Archive</s></button>
-                                    </>
-                                :
-                                    <>
-                                        <button onClick={() => props.onGetResult(election)}>Result</button>
-                                    </>
-                                }
-                                <button><s>Delete</s></button>
-                            </td>
+                            <td>{getButtons(election)}</td>
                         </tr>
                     )})}
                 </tbody>


### PR DESCRIPTION
The enum for elections has been extended to include the status archived. For candidates, a boolean has been added to mark the candidate as archived.

Archived elections show up in a separate table. The election state no longer shows up in the table, as it can be deduced by the user from the available actions.

Not yet implemented: archived candidates will no longer be able to be added to elections. 