### PR TITLE
Feature result table

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,7 @@ import logoutLogo from './assets/logout.svg'
 import loginLogo from './assets/login.svg'
 import voteLogo from './assets/vote.svg'
 
-import type {Candidate, Election, Vote} from "./ElectionData.ts";
+import type {Candidate, Election, STVResultItem, Vote} from "./ElectionData.ts";
 
 import ElectionTable from "./ElectionTable.tsx";
 import NavigationItem from "./NavigationItem.tsx";
@@ -19,6 +19,7 @@ import {Route, Routes, useNavigate} from "react-router-dom";
 import {useEffect, useState} from "react";
 import axios from "axios";
 import AddVoteForm from "./AddVoteForm.tsx";
+import ResultTable from "./ResultTable.tsx";
 
 function App() {
     const nav = useNavigate();
@@ -70,6 +71,7 @@ function App() {
 
     const [currentElection, setCurrentElection] = useState<Election|null>(null);
     const [newVote, setNewVote] = useState<Vote>(defaultVote)
+    const [result, setResult] = useState<STVResultItem[]>([])
 
     // only place to update data
     // could be split to reduce traffic by a small amount
@@ -160,6 +162,8 @@ function App() {
         axios.get("/api/election/results/" + election.id).then(
             (response) => {
                 console.log(response.data)
+                setResult(response.data)
+                nav("/result/")
             }
         )
     }
@@ -306,7 +310,9 @@ function App() {
                     onCreateElection={() => {}}
                     onEditElection={() => {}}
             />}/>
-            <Route path={"/result/"} element={"This is the result page"}/>
+            <Route path={"/result/"} element={<ResultTable
+            result={result}
+            allCandidates={candidates}/>}/>
         </Routes>
     </div>
   )

--- a/frontend/src/ElectionData.ts
+++ b/frontend/src/ElectionData.ts
@@ -30,3 +30,8 @@ export type ElectionResultItem = {
     elected:boolean;
     electedAs:string;
 }
+
+export type STVResultItem = {
+    candidateID:string;
+    votes:string[];
+}

--- a/frontend/src/ElectionTable.tsx
+++ b/frontend/src/ElectionTable.tsx
@@ -51,11 +51,13 @@ export default function ElectionTable(props:Readonly<ElectionTableProps>) {
                                     <>
                                         <button onClick={() => props.onEditElection(election)}>Edit</button>
                                         <button><s>Open Voting</s></button>
+                                        <button onClick={() => props.onGetResult(election)}>(Peek)</button>
                                     </>
                                 :election.electionState === "VOTING"?
                                     <>
                                         <button><s>Close Voting</s></button>
                                         <button><s>Vote</s></button>
+                                        <button onClick={() => props.onGetResult(election)}>(Peek)</button>
                                     </>
                                 :election.electionState === "CLOSED"?
                                     <>

--- a/frontend/src/ResultTable.tsx
+++ b/frontend/src/ResultTable.tsx
@@ -27,7 +27,7 @@ export default function ResultTable(props:Readonly<ResultTableProps>) {
                     <th>Rank</th>
                     <th style={{width:"10px"}}>&nbsp;</th>
                     <th>Candidate</th>
-                    {firstLine.votes.map((_x, i) => {return(<th>Count {i+1}</th>)})}
+                    {firstLine.votes.map((_x, i) => {return(<th key={"result-column-"+i}>Count {i+1}</th>)})}
                 </tr>
             </thead>
             <tbody>

--- a/frontend/src/ResultTable.tsx
+++ b/frontend/src/ResultTable.tsx
@@ -1,0 +1,44 @@
+import type {Candidate, STVResultItem} from "./ElectionData.ts";
+
+export type ResultTableProps = {
+    result:STVResultItem[];
+    allCandidates:Candidate[];
+}
+
+export default function ResultTable(props:Readonly<ResultTableProps>) {
+    const firstLineU:STVResultItem|undefined = props.result.at(0);
+    const firstLine:STVResultItem = firstLineU===undefined?{candidateID:"",votes:[]}:firstLineU;
+
+    return(
+        <div style={{overflow:"scroll", height:"400px", width:"95vw"}}>
+        <table border={1}>
+            <thead>
+                <tr>
+                    <th>Rank</th>
+                    <th style={{width:"10px"}}>&nbsp;</th>
+                    <th>Candidate</th>
+                    {firstLine.votes.map((_x, i) => {return(<th>Count {i+1}</th>)})}
+                </tr>
+            </thead>
+            <tbody>
+            {props.result.map((item, y) => {
+                const candidateU:Candidate|undefined = props.allCandidates.filter(c => c.id === item.candidateID).at(0);
+                const candidate:Candidate = candidateU===undefined?
+                    {name:"Candidate not found",id:"",type:"",archived:false,party:"",color:"",description:""}
+                    :candidateU;
+              return (
+                  <tr>
+                      <th>{y+1}</th>
+                      <th style={{backgroundColor:"#"+candidate.color}}>&nbsp;</th>
+                      <th>{candidate.name}</th>
+                      {item.votes.map(votes => {return(
+                          votes==="ELECTED"?<td style={{backgroundColor:"#6b9"}}>★</td>:votes==="EXCLUDED"?<td style={{backgroundColor:"#f8c"}}>☓</td>:<td>{votes}</td>
+
+                      )})}
+                  </tr>
+              )})}
+            </tbody>
+        </table>
+        </div>
+    )
+}

--- a/frontend/src/ResultTable.tsx
+++ b/frontend/src/ResultTable.tsx
@@ -5,9 +5,19 @@ export type ResultTableProps = {
     allCandidates:Candidate[];
 }
 
+function getResultCell(votes: string, key: string) {
+    if(votes==="ELECTED") {
+        return <td key={key} style={{backgroundColor:"#6b9"}}>★</td>;
+    } else if(votes==="EXCLUDED") {
+        return <td key={key} style={{backgroundColor:"#f8c"}}>☓</td>;
+    } else {
+        return <td key={key}>{votes}</td>;
+    }
+}
+
 export default function ResultTable(props:Readonly<ResultTableProps>) {
     const firstLineU:STVResultItem|undefined = props.result.at(0);
-    const firstLine:STVResultItem = firstLineU===undefined?{candidateID:"",votes:[]}:firstLineU;
+    const firstLine:STVResultItem = firstLineU ?? {candidateID:"",votes:[]};
 
     return(
         <div style={{overflow:"scroll", height:"400px", width:"95vw"}}>
@@ -22,19 +32,20 @@ export default function ResultTable(props:Readonly<ResultTableProps>) {
             </thead>
             <tbody>
             {props.result.map((item, y) => {
-                const candidateU:Candidate|undefined = props.allCandidates.filter(c => c.id === item.candidateID).at(0);
-                const candidate:Candidate = candidateU===undefined?
-                    {name:"Candidate not found",id:"",type:"",archived:false,party:"",color:"",description:""}
-                    :candidateU;
+                const candidateU:Candidate|undefined = props.allCandidates
+                    .filter(c => c.id === item.candidateID)
+                    .at(0);
+                const candidate:Candidate = candidateU ?? {
+                    name:"Candidate not found",id:"",type:"",archived:false,party:"",color:"",description:""};
+
               return (
-                  <tr>
+                  <tr key={"result-row-" + y}>
                       <th>{y+1}</th>
                       <th style={{backgroundColor:"#"+candidate.color}}>&nbsp;</th>
                       <th>{candidate.name}</th>
-                      {item.votes.map(votes => {return(
-                          votes==="ELECTED"?<td style={{backgroundColor:"#6b9"}}>★</td>:votes==="EXCLUDED"?<td style={{backgroundColor:"#f8c"}}>☓</td>:<td>{votes}</td>
-
-                      )})}
+                      {item.votes.map((votes, x) => {
+                          const key:string = "result-cell-" + x +"-" + y;
+                          return(getResultCell(votes, key))})}
                   </tr>
               )})}
             </tbody>


### PR DESCRIPTION
Added a result table. Can be found in the election table. Click on the "Result" button, or the temporary "Peek" buttons. 

The result page shows a table with the counts in the columns and the candidates in the rows. 
The counts are sorted "chronologically", the candidates are sorted by the order in which they have been elected or excluded. The order is neither absolutely accurate nor too relevant, as it is in the end only importand who is elected and who is not, there is no order within the elected or non-elected candidated. However the order in the table makes the count easier to comprehend.