### PR TITLE
Feature advance status

### DIFF
--- a/backend/src/main/java/org/example/backend/controller/ElectionController.java
+++ b/backend/src/main/java/org/example/backend/controller/ElectionController.java
@@ -10,11 +10,11 @@ import org.example.backend.service.ElectionService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.Vector;
 import java.util.Optional;
 
 @RestController
@@ -74,6 +74,12 @@ public class ElectionController {
         } else {
             throw new Election.IdNotFoundException();
         }
+    }
+
+    @DeleteMapping("/{electionId}")
+    public void deleteElection(@PathVariable("electionId") String electionId) {
+        if(!electionService.deleteElection(electionId))
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Object does not exist");
     }
 
     @GetMapping("/candidates")

--- a/backend/src/main/java/org/example/backend/service/ElectionService.java
+++ b/backend/src/main/java/org/example/backend/service/ElectionService.java
@@ -29,4 +29,12 @@ public class ElectionService {
     public Candidate createCandidate(Candidate candidate) { return candidateRepo.save(candidate); }
     public Candidate updateCandidate(Candidate candidate) { return candidateRepo.save(candidate); }
 
+    public boolean deleteElection(String electionId) {
+        Optional<Election> response = electionRepo.findById(electionId);
+        if(response.isPresent()) {
+            electionRepo.deleteById(electionId);
+            return true;
+        }
+        return false;
+    }
 }

--- a/backend/src/test/java/org/example/backend/controller/ElectionControllerTest.java
+++ b/backend/src/test/java/org/example/backend/controller/ElectionControllerTest.java
@@ -389,4 +389,30 @@ public class ElectionControllerTest {
                 .andExpect(MockMvcResultMatchers.status().reason(Election.IdNotFoundException.reason));
 
     }
+
+    @Test
+    void deleteElectionSuccess() throws Exception {
+        //GIVEN
+        electionRepo.deleteAll();
+        electionRepo.save(defaultElection);
+
+        //WHEN
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/election/"+defaultElection.id()))
+
+                //THEN
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+    @Test
+
+    void deleteElectionFail() throws Exception {
+        //GIVEN
+        electionRepo.deleteAll();
+
+        //WHEN
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/election/"+defaultElection.id()))
+
+        //THEN
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
+    }
+
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -98,15 +98,41 @@ function App() {
             })
     }
 
-    function updateElection(election:Election) {
+    function updateElection(election:Election):void {
         axios.put("/api/election", election)
             .then(() => {getAllElectionsAndCandidates(); editElectionProps.onSuccess()})
             .catch(error => {
-                console.log(error);
                 if(error.response && error.response.status == 404) {
                     setEditElectionProps({...editElectionProps, error:error.response.data.message})
                 }
             })
+    }
+
+    function openVoting(election:Election):void {
+        election.electionState = "VOTING";
+        axios.put("/api/election", election)
+            .then(() => {getAllElectionsAndCandidates(); editElectionProps.onSuccess()})
+            .catch(error => { console.log(error) })
+    }
+
+    function closeVoting(election:Election):void {
+        election.electionState = "CLOSED";
+        axios.put("/api/election", election)
+            .then(() => {getAllElectionsAndCandidates(); editElectionProps.onSuccess()})
+            .catch(error => { console.log(error) })
+    }
+
+    function archiveElection(election:Election):void {
+        election.electionState = "ARCHIVED";
+        axios.put("/api/election", election)
+            .then(() => {getAllElectionsAndCandidates(); editElectionProps.onSuccess()})
+            .catch(error => { console.log(error) })
+    }
+
+    function deleteElection(election:Election):void {
+        axios.delete("/api/election/" + election.id)
+            .then(() => {getAllElectionsAndCandidates(); editElectionProps.onSuccess()})
+            .catch(error => { console.log(error) })
     }
 
     function createCandidate(candidate:Candidate):void {
@@ -220,6 +246,10 @@ function App() {
                     })
                     nav("/editElection/")
                 }}
+                onOpenVoting={openVoting}
+                onCloseVoting={closeVoting}
+                onArchiveElection={archiveElection}
+                onDeleteElection={deleteElection}
             />}/>
             <Route path={"/createElection/"} element={<ElectionForm
                 election={editElectionProps.election}
@@ -280,6 +310,10 @@ function App() {
                     isArchive={true}
                     onCreateElection={() => {}}
                     onEditElection={() => {}}
+                    onOpenVoting={() => {}}
+                    onCloseVoting={() => {}}
+                    onArchiveElection={() => {}}
+                    onDeleteElection={deleteElection}
             />}/>
             <Route path={"/result/"} element={"This is the result page"}/>
         </Routes>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -98,15 +98,38 @@ function App() {
             })
     }
 
-    function updateElection(election:Election) {
+    function updateElection(election:Election):void {
         axios.put("/api/election", election)
             .then(() => {getAllElectionsAndCandidates(); editElectionProps.onSuccess()})
             .catch(error => {
-                console.log(error);
                 if(error.response && error.response.status == 404) {
                     setEditElectionProps({...editElectionProps, error:error.response.data.message})
                 }
             })
+    }
+
+    function openVoting(election:Election):void {
+        axios.put("/api/election/status" + election.id, "VOTING")
+            .then(() => {getAllElectionsAndCandidates(); editElectionProps.onSuccess()})
+            .catch(error => { console.log(error) })
+    }
+
+    function closeVoting(election:Election):void {
+        axios.put("/api/election/status" + election.id, "CLOSED")
+            .then(() => {getAllElectionsAndCandidates(); editElectionProps.onSuccess()})
+            .catch(error => { console.log(error) })
+    }
+
+    function archiveElection(election:Election):void {
+        axios.put("/api/election/status" + election.id, "ARCHIVED")
+            .then(() => {getAllElectionsAndCandidates(); editElectionProps.onSuccess()})
+            .catch(error => { console.log(error) })
+    }
+
+    function deleteElection(election:Election):void {
+        axios.delete("/api/election/" + election.id)
+            .then(() => {getAllElectionsAndCandidates(); editElectionProps.onSuccess()})
+            .catch(error => { console.log(error) })
     }
 
     function createCandidate(candidate:Candidate):void {
@@ -220,6 +243,10 @@ function App() {
                     })
                     nav("/editElection/")
                 }}
+                onOpenVoting={openVoting}
+                onCloseVoting={closeVoting}
+                onArchiveElection={archiveElection}
+                onDeleteElection={deleteElection}
             />}/>
             <Route path={"/createElection/"} element={<ElectionForm
                 election={editElectionProps.election}
@@ -280,6 +307,10 @@ function App() {
                     isArchive={true}
                     onCreateElection={() => {}}
                     onEditElection={() => {}}
+                    onOpenVoting={() => {}}
+                    onCloseVoting={() => {}}
+                    onArchiveElection={() => {}}
+                    onDeleteElection={deleteElection}
             />}/>
             <Route path={"/result/"} element={"This is the result page"}/>
         </Routes>

--- a/frontend/src/ElectionTable.tsx
+++ b/frontend/src/ElectionTable.tsx
@@ -6,14 +6,18 @@ export type ElectionTableProps = {
     candidates:Candidate[];
     onCreateElection:()=>void;
     onEditElection:(election:Election)=>void;
+    onOpenVoting:(election:Election)=>void;
+    onCloseVoting:(election:Election)=>void;
+    onArchiveElection:(election:Election)=>void;
     onGetResult:(election:Election)=>void;
+    onDeleteElection:(election:Election)=>void;
     isArchive:boolean;
 }
 
 export default function ElectionTable(props:Readonly<ElectionTableProps>) {
 
     function getDeleteButton(election:Election) {
-        return (<button><s>Delete</s></button>)
+        return (<button onClick={() => props.onDeleteElection(election)}>Delete</button>)
     }
 
     function getResultButton(election:Election) {
@@ -24,19 +28,19 @@ export default function ElectionTable(props:Readonly<ElectionTableProps>) {
         if(election.electionState==="OPEN") {
             return(<>
                 <button onClick={() => props.onEditElection(election)}>Edit</button>
-                <button><s>Open Voting</s></button>
+                <button onClick={() => props.onOpenVoting(election)}>Open Voting</button>
                 {getDeleteButton(election)}
             </>)
         } else if(election.electionState==="VOTING") {
             return(<>
-                <button><s>Close Voting</s></button>
+                <button onClick={() => props.onCloseVoting(election)}>Close Voting</button>
                 <button><s>Vote</s></button>
                 {getDeleteButton(election)}
             </>)
         } else if(election.electionState==="CLOSED") {
             return(<>
                 {getResultButton(election)}
-                <button><s>Archive</s></button>
+                <button onClick={() => props.onArchiveElection(election)}>Archive</button>
                 {getDeleteButton(election)}
             </>)
         } else { // ARCHIVED


### PR DESCRIPTION
The status of elections can now be advanced. A new election is in status OPEN. An open election can be advanced to VOTING, then to CLOSED and then finally to ARCHIVED.

No plausibility checks have been added. So at the moment, an election without candidates can be advanced to VOTING.

Also all elections can now be deleted.

An "unused"-error in ElectionTable.tsx which prevented the deplay has been fixed.