### PR TITLE
Controller function updateElection split and checks added. 

### DIFF
--- a/backend/src/main/java/org/example/backend/controller/ElectionController.java
+++ b/backend/src/main/java/org/example/backend/controller/ElectionController.java
@@ -2,10 +2,7 @@ package org.example.backend.controller;
 
 import org.example.backend.model.count.CountService;
 import org.example.backend.model.count.DetailedResult;
-import org.example.backend.model.db.Candidate;
-import org.example.backend.model.db.CandidateDTO;
-import org.example.backend.model.db.Election;
-import org.example.backend.model.db.ElectionDTO;
+import org.example.backend.model.db.*;
 import org.example.backend.service.ElectionService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -52,13 +49,76 @@ public class ElectionController {
 
     @PutMapping
     public ResponseEntity<Election> updateElection(@RequestBody Election election) {
-        List<Election> allElections = electionService.getAllElections();
-        if(allElections.stream().filter(electionDB -> electionDB.id().equals(election.id())).toList().isEmpty()) {
-            throw new Election.IdNotFoundException();
-        } else {
+        Optional<Election> electionO = electionService.getElectionById(election.id());
+        if(electionO.isEmpty()) throw new Election.IdNotFoundException();
+        Election electionDB = electionO.get();
+
+        // Check for updates prohibited in any case:
+        if(!electionDB.id().equals(election.id())) {
+            throw new Election.IllegalManipulationException("Id cannot be changed");}
+        if(!electionDB.votes().equals(election.votes())) {
+            throw new Election.IllegalManipulationException("Votes cannot be changed through this method");}
+        if(!electionDB.electionState().equals(election.electionState())) {
+            throw new Election.IllegalManipulationException("Status cannot be changed through this method");}
+
+        // If status is OPEN, then any other updates are allowed
+        if(election.electionState() == Election.ElectionState.OPEN)
             return new ResponseEntity<>(
                 electionService.updateElection(election),
                 HttpStatus.ACCEPTED);
+
+        // Otherwise more updates are prohibited
+        if (!electionDB.candidateIDs().equals(election.candidateIDs()))
+            throw new Election.IllegalManipulationException("Candidates cannot be changed unless the election is OPEN");
+        if (!electionDB.candidateType().equals(election.candidateType()))
+            throw new Election.IllegalManipulationException("Candidate Type cannot be changed unless the election is OPEN");
+        if (!electionDB.electionMethod().equals(election.electionMethod()))
+            throw new Election.IllegalManipulationException("Election Method cannot be changed unless the election is OPEN");
+        if (electionDB.seats() != (election.seats()))
+            throw new Election.IllegalManipulationException("Number of Seats cannot be changed unless the election is OPEN");
+
+        // No checks have failed, now the remaining cases (!= OPEN) can be updated
+        return new ResponseEntity<>(
+                electionService.updateElection(election),
+                HttpStatus.ACCEPTED);
+
+    }
+
+    @PostMapping("/advance/{electionId}")
+    public ResponseEntity<Election> advanceElection(@PathVariable("electionId") String electionId) {
+        Optional<Election> electionO = electionService.getElectionById(electionId);
+        if(electionO.isPresent()) {
+            Election electionDB = electionO.get();
+            if(electionDB.electionState() == Election.ElectionState.ARCHIVED) {
+                throw new Election.IllegalManipulationException("Status Archived cannot be advanced");}
+            if(electionDB.electionState() == Election.ElectionState.OPEN &&
+                    electionDB.candidateIDs().size() <= electionDB.seats()) {
+                throw new Election.IllegalManipulationException("Election has too few candidates to be opened");}
+            if(electionDB.electionState() == Election.ElectionState.VOTING &&
+                    electionDB.votes().isEmpty()) {
+                throw new Election.IllegalManipulationException("Election has too few votes to be closed");}
+            return new ResponseEntity<>(
+                    electionService.updateElection(electionDB.advance()),
+                    HttpStatus.ACCEPTED);
+        } else {
+            throw new Election.IdNotFoundException();
+        }
+    }
+
+    @PostMapping("/vote/{electionId}")
+    public ResponseEntity<Election> voteElection(@PathVariable("electionId") String electionId, @RequestBody Vote vote) {
+        Optional<Election> electionO = electionService.getElectionById(electionId);
+        if(electionO.isPresent()) {
+            Election electionDB = electionO.get();
+            if(electionDB.electionState() != Election.ElectionState.VOTING) {
+                throw new Election.IllegalManipulationException("Votes cannot be cast in this state");}
+            if(vote.rankingIDs().isEmpty()) {
+                throw new Election.IllegalManipulationException("Vote cannot be empty");}
+            return new ResponseEntity<>(
+                    electionService.updateElection(electionDB.vote(vote)),
+                    HttpStatus.ACCEPTED);
+        } else {
+            throw new Election.IdNotFoundException();
         }
     }
 
@@ -67,6 +127,7 @@ public class ElectionController {
         Optional<Election> electionO = electionService.getElectionById(electionId);
         List<Candidate> allCandidates = electionService.getAllCandidates();
         if(electionO.isPresent()) {
+            if (electionO.get().votes().isEmpty()) throw new Election.IllegalManipulationException("Empty votes cannot be counted");
             List<DetailedResult.ResultItem> result = CountService.getElectionResult(electionO.get(), allCandidates);
             return new ResponseEntity<>(
                     result,

--- a/backend/src/main/java/org/example/backend/model/db/Election.java
+++ b/backend/src/main/java/org/example/backend/model/db/Election.java
@@ -4,6 +4,7 @@ package org.example.backend.model.db;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public record Election(
@@ -15,16 +16,37 @@ public record Election(
         String candidateType,
         int seats) {
 
+    public Election advance() {
+        if(electionState == ElectionState.ARCHIVED) {throw new IllegalArgumentException("Election has already been archived");}
+        ElectionState next = electionState==ElectionState.OPEN?ElectionState.VOTING:
+                electionState==ElectionState.VOTING?ElectionState.CLOSED:ElectionState.ARCHIVED;
+        return new Election(id, name, description, candidateIDs, votes, next, electionMethod, candidateType, seats);
+    }
+
+    public Election vote(Vote vote) {
+        if(electionState != ElectionState.VOTING) {throw new IllegalArgumentException("Vote cannot be cast if not open for voting");}
+        List<Vote> votes = new ArrayList<>(this.votes);
+        votes.add(vote);
+        return new Election(id, name, description, candidateIDs, votes, electionState, electionMethod, candidateType, seats);
+    }
+
     public enum ElectionState {OPEN, VOTING, CLOSED, ARCHIVED}
     public enum ElectionType {STV, VICE}
 
-    @ResponseStatus(value= HttpStatus.FORBIDDEN, reason=DuplicateIdException.reason)
+    @ResponseStatus(value=HttpStatus.FORBIDDEN, reason=DuplicateIdException.reason)
     public static class DuplicateIdException extends RuntimeException {
         public static final String reason = "Duplicate ID";
     }
 
-    @ResponseStatus(value= HttpStatus.NOT_FOUND, reason=IdNotFoundException.reason)
+    @ResponseStatus(value=HttpStatus.NOT_FOUND, reason=IdNotFoundException.reason)
     public static class IdNotFoundException extends RuntimeException {
         public static final String reason = "ID not found";
+    }
+
+    @ResponseStatus(value=HttpStatus.FORBIDDEN)
+    public static class IllegalManipulationException extends RuntimeException {
+        public IllegalManipulationException(String message) {
+            super(message);
+        }
     }
 }

--- a/backend/src/test/java/org/example/backend/controller/CandidateControllerTest.java
+++ b/backend/src/test/java/org/example/backend/controller/CandidateControllerTest.java
@@ -1,9 +1,7 @@
 package org.example.backend.controller;
 
 import org.example.backend.model.db.Candidate;
-import org.example.backend.model.db.Election;
 import org.example.backend.repository.CandidateRepo;
-import org.example.backend.repository.ElectionRepo;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -13,11 +11,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-import java.util.ArrayList;
-
 @SpringBootTest
 @AutoConfigureMockMvc
-public class CandidateControllerTest {
+class CandidateControllerTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/backend/src/test/java/org/example/backend/controller/ElectionControllerTest.java
+++ b/backend/src/test/java/org/example/backend/controller/ElectionControllerTest.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-public class ElectionControllerTest {
+class ElectionControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -30,7 +30,7 @@ public class ElectionControllerTest {
     @Autowired
     private CandidateRepo candidateRepo;
 
-    Election OPEN_ELECTION = new Election(
+    final Election OPEN_ELECTION = new Election(
             "id1",
             "MyElection",
             "some details",
@@ -41,7 +41,7 @@ public class ElectionControllerTest {
             "Person",
             3);
 
-    Election VOTING_ELECTION = new Election(
+    final Election VOTING_ELECTION = new Election(
             "id2",
             "MyElection",
             "some details",

--- a/backend/src/test/java/org/example/backend/model/db/ElectionTest.java
+++ b/backend/src/test/java/org/example/backend/model/db/ElectionTest.java
@@ -1,0 +1,58 @@
+package org.example.backend.model.db;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ElectionTest {
+
+    private final Election DEFAULT_ELECTION = new Election("id", "name", "description",
+            List.of("candidateId"), new ArrayList<>(), Election.ElectionState.VOTING, Election.ElectionType.STV,
+            "Person", 2);
+
+    @Test
+    void advance() {
+        //GIVEN
+        Election e = DEFAULT_ELECTION;
+
+        //WHEN
+        Election f = e.advance();
+
+        //THEN
+        assertEquals(e.id(), f.id());
+        assertEquals(e.votes(), f.votes());
+        assertEquals(Election.ElectionState.CLOSED, f.electionState());
+    }
+
+    @Test
+    void vote() {
+        //GIVEN
+        Election e = DEFAULT_ELECTION;
+
+        //WHEN
+        Election f = e.vote(new Vote(Arrays.asList("A", "B")));
+        Election g = f.vote(new Vote(Arrays.asList("C", "D")));
+
+        //THEN
+        assertEquals(e.id(), g.id());
+        assertEquals(e.electionState(), g.electionState());
+        assertEquals(Arrays.asList(new Vote(Arrays.asList("A", "B")), new Vote(Arrays.asList("C", "D"))), g.votes());
+    }
+
+    @Test
+    void voteFail() {
+        //GIVEN
+        Election e = DEFAULT_ELECTION;
+
+        //WHEN
+        e = e.vote(new Vote(Arrays.asList("A", "B")));
+        final Election f = e.advance();
+
+        //THEN
+        assertThrows(Exception.class, () -> f.vote(new Vote(Arrays.asList("C", "D"))));
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -117,22 +117,19 @@ function App() {
     }
 
     function openVoting(election:Election):void {
-        election.electionState = "VOTING";
-        axios.put("/api/election", election)
+        axios.post("api/election/advance/" + election.id)
             .then(() => {getAllElectionsAndCandidates(); editElectionProps.onSuccess()})
             .catch(error => { console.log(error) })
     }
 
     function closeVoting(election:Election):void {
-        election.electionState = "CLOSED";
-        axios.put("/api/election", election)
+        axios.post("api/election/advance/" + election.id)
             .then(() => {getAllElectionsAndCandidates(); editElectionProps.onSuccess()})
             .catch(error => { console.log(error) })
     }
 
     function archiveElection(election:Election):void {
-        election.electionState = "ARCHIVED";
-        axios.put("/api/election", election)
+        axios.post("api/election/advance/" + election.id)
             .then(() => {getAllElectionsAndCandidates(); editElectionProps.onSuccess()})
             .catch(error => { console.log(error) })
     }
@@ -198,8 +195,7 @@ function App() {
     function submitVote():void {
         const election:Election|null = currentElection
         if(election) {
-            election.votes.push(newVote);
-            axios.put("/api/election", election).then(() => {
+            axios.post("/api/election/vote/" + election.id, newVote).then(() => {
                 setNewVote(defaultVote);
                 setCurrentElection(null);
                 getAllElectionsAndCandidates();

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -116,23 +116,8 @@ function App() {
             })
     }
 
-    function openVoting(election:Election):void {
-        election.electionState = "VOTING";
-        axios.put("/api/election", election)
-            .then(() => {getAllElectionsAndCandidates(); editElectionProps.onSuccess()})
-            .catch(error => { console.log(error) })
-    }
-
-    function closeVoting(election:Election):void {
-        election.electionState = "CLOSED";
-        axios.put("/api/election", election)
-            .then(() => {getAllElectionsAndCandidates(); editElectionProps.onSuccess()})
-            .catch(error => { console.log(error) })
-    }
-
-    function archiveElection(election:Election):void {
-        election.electionState = "ARCHIVED";
-        axios.put("/api/election", election)
+    function advanceElection(election:Election):void {
+        axios.post("api/election/advance/" + election.id)
             .then(() => {getAllElectionsAndCandidates(); editElectionProps.onSuccess()})
             .catch(error => { console.log(error) })
     }
@@ -198,8 +183,7 @@ function App() {
     function submitVote():void {
         const election:Election|null = currentElection
         if(election) {
-            election.votes.push(newVote);
-            axios.put("/api/election", election).then(() => {
+            axios.post("/api/election/vote/" + election.id, newVote).then(() => {
                 setNewVote(defaultVote);
                 setCurrentElection(null);
                 getAllElectionsAndCandidates();
@@ -268,9 +252,7 @@ function App() {
                     })
                     nav("/editElection/")
                 }}
-                onOpenVoting={openVoting}
-                onCloseVoting={closeVoting}
-                onArchiveElection={archiveElection}
+                onAdvanceElection={advanceElection}
                 onDeleteElection={deleteElection}
             />}/>
             <Route path={"/createElection/"} element={<ElectionForm
@@ -341,9 +323,7 @@ function App() {
                     isArchive={true}
                     onCreateElection={() => {}}
                     onEditElection={() => {}}
-                    onOpenVoting={() => {}}
-                    onCloseVoting={() => {}}
-                    onArchiveElection={() => {}}
+                    onAdvanceElection={() => {}}
                     onDeleteElection={deleteElection}
             />}/>
             <Route path={"/result/"} element={<ResultTable

--- a/frontend/src/ElectionTable.tsx
+++ b/frontend/src/ElectionTable.tsx
@@ -8,9 +8,7 @@ export type ElectionTableProps = {
     candidates:Candidate[];
     onCreateElection:()=>void;
     onEditElection:(election:Election)=>void;
-    onOpenVoting:(election:Election)=>void;
-    onCloseVoting:(election:Election)=>void;
-    onArchiveElection:(election:Election)=>void;
+    onAdvanceElection:(election:Election)=>void;
     onGetResult:(election:Election)=>void;
     onDeleteElection:(election:Election)=>void;
     isArchive:boolean;
@@ -37,14 +35,14 @@ export default function ElectionTable(props:Readonly<ElectionTableProps>) {
         if(election.electionState==="OPEN") {
             return(<>
                 <button onClick={() => props.onEditElection(election)}>Edit</button>
-                <button onClick={() => props.onOpenVoting(election)}>Open Voting</button>
+                <button onClick={() => props.onAdvanceElection(election)}>Open Voting</button>
                 <button onClick={() => props.onGetResult(election)}>(Peek)</button>
                 {getDeleteButton(election)}
             </>)
         } else if(election.electionState==="VOTING") {
             return(<>
                 <button onClick={() => props.onEditElection(election)}>Edit</button>
-                <button onClick={() => props.onCloseVoting(election)}>Close Voting</button>
+                <button onClick={() => props.onAdvanceElection(election)}>Close Voting</button>
                 <button><s>Vote</s></button>
                 <button onClick={() => props.onGetResult(election)}>(Peek)</button>
                 {getDeleteButton(election)}
@@ -52,7 +50,7 @@ export default function ElectionTable(props:Readonly<ElectionTableProps>) {
         } else if(election.electionState==="CLOSED") {
             return(<>
                 {getResultButton(election)}
-                <button onClick={() => props.onArchiveElection(election)}>Archive</button>
+                <button onClick={() => props.onAdvanceElection(election)}>Archive</button>
                 {getDeleteButton(election)}
             </>)
         } else { // ARCHIVED


### PR DESCRIPTION
- edit election -> remains, but
  - always prevent (id), status & vote change.
  - further prevent change candidate, seats, type & method unless open.
  -description, name always editable
- change election status -> add 3 separate post requests with empty body (openVoting, closeVoting, archiveElection)
- addVote -> add new post request
- changeVote, deleteVote -> never possible
- create election, delete election -> remain as is
